### PR TITLE
Update opsvis.py

### DIFF
--- a/src/opsvis/opsvis.py
+++ b/src/opsvis/opsvis.py
@@ -2443,7 +2443,7 @@ def plot_mode_shape(modeNo, sfac=False, nep=17, unDefoFlag=1,
 def bar_length(ex, ey, ez=np.array([0., 0.])):
     Lxyz = np.array([ex[1]-ex[0], ey[1]-ey[0], ez[1]-ez[0]])
     L = np.sqrt(Lxyz @ Lxyz)
-    print(f'Lxyz: {Lxyz}, L: {L}')
+    #print(f'Lxyz: {Lxyz}, L: {L}')
 
     return L
 


### PR DESCRIPTION
Hi dear @sewkokot 
The [print(f'Lxyz: {Lxyz}, L: {L}')] in line 2446 has made some problems specially in Jupyter plots. After any plots a lot of data appear (An example has been shown in the following). If it is not necessary to view, That would be great if you hide it.Thank you ... 

With best,
Bijan

![image](https://user-images.githubusercontent.com/82403633/147393227-20e717d7-ab3d-46d3-96e4-e299bd0f2977.png)
