### PR TITLE
Box aspect ratio for plot_extruded_shapes_3d

### DIFF
--- a/src/opsvis/opsvis.py
+++ b/src/opsvis/opsvis.py
@@ -5383,7 +5383,7 @@ def plot_extruded_shapes_3d(ele_shapes, az_el=az_el,
                    lw=2, length=alen, alpha=.8, normalize=True)
         plt.quiver(Xm, Ym, Zm, g[2, 0], g[2, 1], g[2, 2], color='r',
                    lw=2, length=alen, alpha=.8, normalize=True)
-    
+
     # Get box aspect ratio according to the structure's general layout:
     ymin, ymax = ax.get_ylim()
     xmin, xmax = ax.get_xlim()

--- a/src/opsvis/opsvis.py
+++ b/src/opsvis/opsvis.py
@@ -5383,7 +5383,12 @@ def plot_extruded_shapes_3d(ele_shapes, az_el=az_el,
                    lw=2, length=alen, alpha=.8, normalize=True)
         plt.quiver(Xm, Ym, Zm, g[2, 0], g[2, 1], g[2, 2], color='r',
                    lw=2, length=alen, alpha=.8, normalize=True)
-
+    
+    # Get box aspect ratio according to the structure's general layout:
+    ymin, ymax = ax.get_ylim()
+    xmin, xmax = ax.get_xlim()
+    zmin, zmax = ax.get_zlim()
+    ax.set_box_aspect(aspect = ((xmax-xmin)/(xmax-xmin),(ymax-ymin)/(xmax-xmin),(zmax-zmin)/(xmax-xmin)))
 
 def _plot_extruded_shapes_3d_double_T(ex, ey, ez, g, shape_args):
     bf, d, tw, tf = shape_args


### PR DESCRIPTION
To set the box aspect ratio for plot_extruded_shapes_3d in ops.vis, based on the axes range of one structure's layout.