### PR TITLE
Fix display of fixed supports for 2D models

### DIFF
--- a/src/opsvis/opsvis.py
+++ b/src/opsvis/opsvis.py
@@ -3615,6 +3615,7 @@ def plot_supports_and_loads_2d(nep=17, sfac=False):
     node_tags = ops.getNodeTags()
     ele_tags = ops.getEleTags()
     ndim = np.shape(ops.nodeCoord(node_tags[0]))[0]
+    ndofs = np.shape(ops.nodeDOFs(node_tags[0]))[0]
 
     # calculate sfac
     min_x, min_y = np.inf, np.inf
@@ -3830,7 +3831,7 @@ def plot_supports_and_loads_2d(nep=17, sfac=False):
 
         marker_type=''
 
-        if ndim < 3:
+        if ndofs < 3:
             if node_dofs[0] == -1 and node_dofs[1] == -1:
                 marker_type = '^m'
             elif node_dofs[0] == -1 or node_dofs[1] == -1:


### PR DESCRIPTION
`plot_supports_and_loads_2d()` used _the number of dimensions_ (`ndim`), which is 2 for 2D models by definition, to determine whether rotationally-restrained supports are possible, which led to all supports being displayed as triangles (pins). See https://github.com/sewkokot/opsvis/issues/17.

Revised to use _the number of DOFs per node_ (`ndofs`) to determine whether rotationally-restrained supports are possible, so that fixed supports are displayed appropriately.