### PR TITLE
Fiber section invert_xaxis() for z-coordinate

### DIFF
--- a/src/opsvis/opsvis.py
+++ b/src/opsvis/opsvis.py
@@ -2650,6 +2650,7 @@ def plot_fiber_section(fib_sec_list, fillflag=1,
 
     fig, ax = plt.subplots()
     ax.set_xlabel('z')
+    ax.invert_xaxis() # To make z-axis positive to the left
     ax.set_ylabel('y')
     ax.grid(False)
 


### PR DESCRIPTION
Adding call to invert_xaxis() in plot_fiber_section so that the section z-coordinate is positive to the right like in most documentation. Without inverting the axis, it can be confusing when building patches one at a time and seeing the patches "on the wrong side".