### PR TITLE
Fix relative imports

### DIFF
--- a/opsvis/__init__.py
+++ b/opsvis/__init__.py
@@ -1,6 +1,3 @@
-# For relative imports to work in Python 3.6
-import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-
 from .settings import *
 from .model import *
 from .defo import *

--- a/opsvis/anim.py
+++ b/opsvis/anim.py
@@ -3,8 +3,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
-from settings import *
-from defo import *
+from .settings import *
+from .defo import *
 
 
 def _anim_mode_2d(modeNo, sfac, nep, unDefoFlag, fmt_defo, fmt_undefo,

--- a/opsvis/defo.py
+++ b/opsvis/defo.py
@@ -8,8 +8,8 @@ from matplotlib.patches import Circle, Polygon, Wedge
 from matplotlib.animation import FuncAnimation
 import matplotlib.tri as tri
 
-from settings import *
-import model as opsvmodel
+from .settings import *
+from . import model as opsvmodel
 
 
 def _plot_defo_mode_2d(modeNo, sfac, nep, unDefoFlag, fmt_defo, fmt_undefo,

--- a/opsvis/fibsec.py
+++ b/opsvis/fibsec.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, Polygon, Wedge
 
-from settings import *
+from .settings import *
 
 
 # plot_fiber_section is inspired by plotSection matlab function

--- a/opsvis/model.py
+++ b/opsvis/model.py
@@ -6,11 +6,11 @@ from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from matplotlib.collections import PolyCollection
 from matplotlib.patches import Circle, Polygon, Wedge
 from matplotlib.animation import FuncAnimation
+from matplotlib.path import Path
 import matplotlib.tri as tri
 
-from settings import *
-from defo import *
-from matplotlib.path import Path
+from .settings import *
+from .defo import *
 
 
 def _plot_model_2d(node_labels, element_labels, offset_nd_label, axis_off,

--- a/opsvis/secforces.py
+++ b/opsvis/secforces.py
@@ -8,8 +8,8 @@ from matplotlib.patches import Circle, Polygon, Wedge
 from matplotlib.animation import FuncAnimation
 import matplotlib.tri as tri
 
-from settings import *
-import model
+from .settings import *
+from . import model
 
 
 def section_force_distribution_2d(ecrd, pl, nep=2,

--- a/opsvis/stress.py
+++ b/opsvis/stress.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 
-from settings import *
+from .settings import *
 
 
 def stress_2d_ele_tags_only(ele_tags):


### PR DESCRIPTION
Closes #30.

Previously, relative imports were being achieved by manipulating the `sys.path` variable, instead of using actual relative imports. This causes conflicts with other files, such as described in #30.