### PR TITLE
Adding pipe elements to opsvis

### DIFF
--- a/opsvis/model.py
+++ b/opsvis/model.py
@@ -624,7 +624,9 @@ def _plot_model_3d(node_labels, element_labels, offset_nd_label,
         if (ele_classtag == EleClassTag.ElasticBeam3d or
             ele_classtag == EleClassTag.ForceBeamColumn3d or
             ele_classtag == EleClassTag.DispBeamColumn3d or
-            ele_classtag == EleClassTag.ElasticTimoshenkoBeam3d):
+            ele_classtag == EleClassTag.ElasticTimoshenkoBeam3d or
+            ele_classtag == EleClassTag.Pipe or
+            ele_classtag == EleClassTag.CurvedPipe):
 
             nen = 2
             ele_node_tags = ops.eleNodes(ele_tag)

--- a/opsvis/settings.py
+++ b/opsvis/settings.py
@@ -99,6 +99,8 @@ class EleClassTag:
     MVLEM_3D = 212
     SFI_MVLEM_3D = 213
     TwoNodeLink = 86
+    Pipe = 269
+    CurvedPipe = 270
 
 
 class LoadTag:


### PR DESCRIPTION
`Pipe` - straight pipe, drawn like 3d beams
`CurvedPipe` - curved, but drawn as straight pipe for now

Elements are available in `openseespy>=3.7.0.3`